### PR TITLE
Update login instructions

### DIFF
--- a/app/NewRootComponent.tsx
+++ b/app/NewRootComponent.tsx
@@ -110,7 +110,7 @@ const LoggedOutRoot: React.FC = () => {
   };
 
   return (
-    <NotLoggedInPanel bannerText="You need to log in to access the Multimedia production system, using your normal Mac password">
+    <NotLoggedInPanel bannerText="You need to log in to access the Multimedia production system. When prompted enter your email address in the format firstname.lastname@theguardian.com, and then approve on your phone if prompted from the Microsoft Authenticator app">
       <Grid item>
         <Button
           style={{ marginLeft: "auto", marginRight: "auto" }}


### PR DESCRIPTION

## What does this change?

Updated the text when a user logs in to: "You need to log in to access the Multimedia production system.

When prompted enter your email address in the format [firstname.lastname@theguardian.com](mailto:firstname.lastname@theguardian.com), and then approve on your phone if prompted from the Microsoft Authenticator app"


