### PR TITLE
Making Panels Less Transparent

### DIFF
--- a/app/panels/PanelsCommon.tsx
+++ b/app/panels/PanelsCommon.tsx
@@ -7,7 +7,7 @@ interface ProjectsPanelProps {
 
 const usePanelStyles = makeStyles((theme) => ({
   panel: {
-    backgroundColor: theme.palette.type == "dark" ? "#424242D0" : "#FBFBFBD0",
+    backgroundColor: theme.palette.type == "dark" ? "#424242E5" : "#FBFBFBE5",
   },
 }));
 

--- a/app/panels/PanelsCommon.tsx
+++ b/app/panels/PanelsCommon.tsx
@@ -7,7 +7,7 @@ interface ProjectsPanelProps {
 
 const usePanelStyles = makeStyles((theme) => ({
   panel: {
-    backgroundColor: theme.palette.type == "dark" ? "#424242A0" : "#FBFBFBA0",
+    backgroundColor: theme.palette.type == "dark" ? "#424242D0" : "#FBFBFBD0",
   },
 }));
 


### PR DESCRIPTION
## What does this change?

Makes panels less transparent.

## How can we measure success?

Panels are less transparent.

## Images

![Screenshot 2024-04-04 at 10 56 04](https://github.com/guardian/pluto-start/assets/10620802/b6c70715-59e0-4f77-aea7-e4f0ce2b83c2)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.