### PR TITLE
Use a New Version of Pluto Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
-    "@guardian/pluto-headers": "^2.0.0-pre6",
+    "@guardian/pluto-headers": "^2.1.1",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.58",

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,14 +508,14 @@
     "@floating-ui/dom" "^1.6.1"
 
 "@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
-  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
-"@guardian/pluto-headers@^2.0.0-pre6":
-  version "2.0.0-pre6"
-  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.0.0-pre6/aeac139436b237f7814c73444b815ee003ba02d8bd06c38087072bac42e5ba69#385ffebd003900a82a80740d5e8d4aa1f7c1408d"
-  integrity sha512-AOJ4rVFDNbl/oHYuHmwHzE1hEgfTI3c++PPeRrgb3liFG2/HzuWNyaQnh3hqDBODweiHuO5RIgsNGRsI/KbXvQ==
+"@guardian/pluto-headers@^2.1.1":
+  version "2.1.1"
+  resolved "https://npm.pkg.github.com/download/@guardian/pluto-headers/2.1.1/cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e#cf8f63c25f46a15ab7c3c23b73e1c65230f07b1e"
+  integrity sha512-AsAoCnQDS9V2RNMDJIdi6KlZaKUw8iczWH9lWyKwkS666p46H83O8+FBTceui1M1LKLNfQSV2MW/MyQUYOyC9Q==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?

Uses a new version of Pluto Headers which has a help button.

## How can we measure success?

The new version of Pluto Headers is used.

## Images

![Screenshot 2024-12-18 at 16 26 45](https://github.com/user-attachments/assets/9e586321-64cb-411f-8ef8-910a794e941d)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.